### PR TITLE
Update front-edit.js

### DIFF
--- a/front/static/front/js/front-edit.js
+++ b/front/static/front/js/front-edit.js
@@ -36,8 +36,8 @@
         target.find('.cancel').on('click', function(event) {
             el.html(html);
             body.removeClass('front-editing');
-            jQuery('#front-edit-lightbox-container').remove();
             front_edit_plugin.destroy_editor();
+            jQuery('#front-edit-lightbox-container').remove();
         });
 
         target.find('.history').on('click', function(event) {


### PR DESCRIPTION
Editor should be destroyed before removing HTML element or in other case it'll throw Exception

```
TypeError: a is null
 at g<.proto.detach (/static/bower_components/ckeditor/ckeditor.js:931:281)
 at CKEDITOR.editor.prototype.editable (/static/bower_components/ckeditor/ckeditor.js:326:340)
 at .destroy (/static/bower_components/ckeditor/ckeditor.js:228:302)
 at front_edit_plugin.destroy_editor (/static/front/js/front-edit.ckeditor.js:29:9)
 at triggerEditor/< (/static/front/js/front-edit.js:95:13)
```
