### PR TITLE
Update front-edit.js

### DIFF
--- a/front/static/front/js/front-edit.js
+++ b/front/static/front/js/front-edit.js
@@ -89,9 +89,9 @@
             });
             body.removeClass('front-editing');
             el.html(new_html);
-            jQuery('#front-edit-lightbox-container').remove();
             // cleanup callback
             front_edit_plugin.destroy_editor();
+            jQuery('#front-edit-lightbox-container').remove();
         });
     };
 


### PR DESCRIPTION
Editor should be destroyed before removing HTML element or in other case it'll throw Exception
